### PR TITLE
Add: 네브바 반응형, Outlet, useNavigate 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "firebase": "^9.12.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.6.0",
         "react-redux": "^8.0.4",
         "react-router": "^6.4.2",
         "react-router-dom": "^6.4.2",
@@ -14843,6 +14844,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.6.0.tgz",
+      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -28380,6 +28389,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.6.0.tgz",
+      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "firebase": "^9.12.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.6.0",
     "react-redux": "^8.0.4",
     "react-router": "^6.4.2",
     "react-router-dom": "^6.4.2",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -8,11 +8,12 @@ import { ReservationCheck } from "../pages/ReservationCheck/ReservationCheck";
 export function App() {
   return (
     <BrowserRouter>
-      <Nav />
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/reservation" element={<Reservation />} />
-        <Route path="/reservation/check" element={<ReservationCheck />} />
+        <Route element={<Nav />}>
+          <Route path="/" element={<Home />} />
+          <Route path="/reservation" element={<Reservation />} />
+          <Route path="/reservation/check" element={<ReservationCheck />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,5 +1,109 @@
 import React from "react";
+import styled from "styled-components";
+import { useNavigate, Outlet } from "react-router-dom";
+import { HiScissors } from "react-icons/hi";
 
 export function Nav() {
-  return <div>Nav</div>;
+  const navigate = useNavigate();
+
+  return (
+    <Container>
+      <nav>
+        <ul>
+          <button type="button" onClick={() => navigate("/")}>
+            <li>
+              <HiScissors />
+              JHair
+            </li>
+          </button>
+          <button type="button" onClick={() => navigate("/reservation")}>
+            <li>예약하기</li>
+          </button>
+          <button type="button" onClick={() => navigate("/reservation/check")}>
+            <li>예약확인</li>
+          </button>
+        </ul>
+      </nav>
+      <Dashboard>
+        <Outlet />
+      </Dashboard>
+    </Container>
+  );
 }
+
+const deviceSizes = {
+  mobile: "375px",
+  tablet: "768px",
+  desktop: "1024px",
+};
+
+const device = {
+  mobile: `@media only screen and (max-width: ${deviceSizes.mobile})`,
+  tablet: `@media only screen and (min-width: ${deviceSizes.tablet}) and (max-width: ${deviceSizes.desktop})`,
+  desktop: `@media only screen and (min-width: ${deviceSizes.desktop})`,
+};
+
+const Container = styled.main`
+  margin: 300px auto;
+  width: 100%;
+  max-width: 100vw;
+  min-width: ${deviceSizes.mobile};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #ffffff;
+  box-shadow: 5px 5px 10px;
+
+  > nav {
+    display: flex;
+    margin: 20px 0;
+
+    height: 40px;
+
+    > ul {
+      display: flex;
+      flex-direction: rows;
+      align-items: center;
+      justify-content: center;
+
+      > button > li {
+        width: 140px;
+        display: flex;
+        font-size: 22px;
+        color: #5e5e5e;
+        font-weight: 600;
+        justify-content: center;
+      }
+    }
+  }
+
+  ${device.tablet} {
+    width: 100%;
+  }
+
+  ${device.desktop} {
+    width: 80%;
+    max-width: 1000px;
+    height: 100%;
+    box-sizing: border-box;
+    background-color: #ffffff;
+    box-shadow: 1px 3px 10px;
+  }
+`;
+
+const Dashboard = styled.div`
+  width: 100%;
+  padding: 40px;
+  background-color: #f9e5e6;
+
+  ${device.desktop} {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto;
+    grid-template-areas: "wave wrapper";
+    width: 100%;
+    min-width: fit-content;
+    height: 100%;
+    background-color: #f9e5e6;
+  }
+`;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,5 +1,5 @@
 import React from "react";
 
 export function Home() {
-  return <div>냥냐야냥</div>;
+  return <div>Home</div>;
 }

--- a/src/pages/ReservationCheck/ReservationCheck.tsx
+++ b/src/pages/ReservationCheck/ReservationCheck.tsx
@@ -1,5 +1,5 @@
 import React from "react";
 
 export function ReservationCheck() {
-  return <div />;
+  return <div>ReservationCheck</div>;
 }


### PR DESCRIPTION
# :: 구현 목표
- 네브바에서 전체를 감싸고 Outlet으로 메뉴들 이동하게 하기
- 반응형 레이아웃 구현
- 시멘틱 테그 사용

# :: 구현 사항 설명
![스크린샷 2022-10-21 오후 6 34 58](https://user-images.githubusercontent.com/78889402/197165710-ce48dab2-df70-4af1-9c52-16693fd58353.png)
- `Container - nav  > Dashboard - Oulet` 으로 반응형 레이아웃 구현 완료
- Container는 `main`, 네브는 `nav`으로 시멘틱 테그 사용
- 각 메뉴를 누를 시, 해당 페이지로 이동 : `useNavigate`사용
- `react-icons` 설치 후 가위 아이콘 적용